### PR TITLE
Basic 認証周りの改修

### DIFF
--- a/node/src/app.test.ts
+++ b/node/src/app.test.ts
@@ -88,6 +88,35 @@ await test('Compression', async (t) => {
 	});
 });
 
+await test('401', async (t) => {
+	await t.test('normal', async () => {
+		const res = await app.request('/api/');
+
+		assert.equal(res.status, 401);
+		assert.equal(res.headers.get('Content-Type'), 'text/html; charset=UTF-8');
+		assert.equal(/^Basic realm=".+"$/.test(res.headers.get('WWW-Authenticate')!), true);
+		assert.deepStrictEqual(
+			await res.text(),
+			`<!DOCTYPE html>
+<html lang=en>
+<meta name=viewport content="width=device-width,initial-scale=1">
+<title>media.w0s.jp</title>
+<h1>Client error</h1>`,
+		);
+	});
+
+	await t.test('API', async () => {
+		const res = await app.request('/api/', {
+			method: 'post',
+		});
+
+		assert.equal(res.status, 401);
+		assert.equal(res.headers.get('Content-Type'), 'application/json');
+		assert.equal(res.headers.get('WWW-Authenticate'), null);
+		/* assert.deepStrictEqual(await res.json(), { message: config.basicAuth.unauthorizedMessage }); */ // TODO: https://github.com/SaekiTominaga/media.w0s.jp/issues/85
+	});
+});
+
 await test('404', async (t) => {
 	await t.test('normal', async () => {
 		const res = await app.request('/foo');

--- a/node/src/app.ts
+++ b/node/src/app.ts
@@ -117,13 +117,11 @@ const auth = await getAuth();
 app.use(
 	`/${config.api.dir}/*`,
 	basicAuth({
-		username: auth.user,
-		password: auth.password,
-		realm: auth.realm,
 		verifyUser: (username, password) => {
 			const passwordHash = crypto.hash('sha256', password);
 			return username === auth.user && passwordHash === auth.password;
 		},
+		realm: auth.realm,
 		invalidUserMessage: {
 			message: config.basicAuth.unauthorizedMessage,
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
 		"": {
 			"name": "media.w0s.jp",
 			"dependencies": {
-				"@hono/node-server": "^1.13.7",
+				"@hono/node-server": "^1.13.8",
 				"@log4js-node/smtp": "^2.0.8",
 				"@w0s/file-size-format": "^3.0.0",
 				"dotenv": "^16.4.7",
 				"ejs": "^3.1.10",
-				"hono": "^4.6.19",
+				"hono": "^4.6.20",
 				"image-size": "^1.2.0",
 				"log4js": "^6.9.1",
 				"qs": "^6.14.0",
@@ -744,9 +744,9 @@
 			"optional": true
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.13.7",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.13.7.tgz",
-			"integrity": "sha512-kTfUMsoloVKtRA2fLiGSd9qBddmru9KadNyhJCwgKBxTiNkaAJEwkVN9KV/rS4HtmmNRtUh6P+YpmjRMl0d9vQ==",
+			"version": "1.13.8",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.13.8.tgz",
+			"integrity": "sha512-fsn8ucecsAXUoVxrUil0m13kOEq4mkX4/4QozCqmY+HpGfKl74OYSn8JcMA8GnG0ClfdRI4/ZSeG7zhFaVg+wg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.14.1"
@@ -4148,9 +4148,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.6.19",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.6.19.tgz",
-			"integrity": "sha512-Xw5DwU2cewEsQ1DkDCdy6aBJkEBARl5loovoL1gL3/gw81RdaPbXrNJYp3LoQpzpJ7ECC/1OFi/vn3UZTLHFEw==",
+			"version": "4.6.20",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.6.20.tgz",
+			"integrity": "sha512-5qfNQeaIptMaJKyoJ6N/q4gIq0DBp2FCRaLNuUI3LlJKL4S37DY/rLL1uAxA4wrPB39tJ3s+f7kgI79O4ScSug==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
 		"yaml-lint": "yamllint .github/workflows/*.yml"
 	},
 	"dependencies": {
-		"@hono/node-server": "^1.13.7",
+		"@hono/node-server": "^1.13.8",
 		"@log4js-node/smtp": "^2.0.8",
 		"@w0s/file-size-format": "^3.0.0",
 		"dotenv": "^16.4.7",
 		"ejs": "^3.1.10",
-		"hono": "^4.6.19",
+		"hono": "^4.6.20",
 		"image-size": "^1.2.0",
 		"log4js": "^6.9.1",
 		"qs": "^6.14.0",


### PR DESCRIPTION
- `basicAuth()` の不要な指定を削除
- 401 における `WWW-Authenticate` ヘッダーを設定（ただし現状は Basic 認証は API 利用時のみに使用しており、Web ブラウザで認証ダイアログを開くケースは存在しない）