### PR TITLE
PNG8 判定条件を変更

### DIFF
--- a/node/src/util/thumbImage.test.ts
+++ b/node/src/util/thumbImage.test.ts
@@ -84,10 +84,26 @@ await test('create()', async (t) => {
 		assert.equal(fs.existsSync(thumbImage.fileFullPath), true);
 	});
 
-	await t.test('PNG', async () => {
-		const thumbImage = new ThumbImage(dir, { fileBasePath: 'test.jpg', type: 'png', size: { width: 100, height: 200 }, quality: undefined });
+	await t.test('JPEG→PNG', async () => {
+		const thumbImage = new ThumbImage(dir, { fileBasePath: 'test-jpeg.jpg', type: 'png', size: { width: 100, height: 200 }, quality: undefined });
 
 		await create(`${config.static.root}/${config.static.directory.image}/sample.jpg`, thumbImage);
+
+		assert.equal(fs.existsSync(thumbImage.fileFullPath), true);
+	});
+
+	await t.test('PNG8→PNG', async () => {
+		const thumbImage = new ThumbImage(dir, { fileBasePath: 'test-png8.png', type: 'png', size: { width: 101, height: 201 }, quality: undefined });
+
+		await create(`${config.static.root}/${config.static.directory.image}/sample-png8.png`, thumbImage);
+
+		assert.equal(fs.existsSync(thumbImage.fileFullPath), true);
+	});
+
+	await t.test('PNG32→PNG', async () => {
+		const thumbImage = new ThumbImage(dir, { fileBasePath: 'test-png32.png', type: 'png', size: { width: 102, height: 202 }, quality: undefined });
+
+		await create(`${config.static.root}/${config.static.directory.image}/sample-png32.png`, thumbImage);
 
 		assert.equal(fs.existsSync(thumbImage.fileFullPath), true);
 	});

--- a/node/src/util/thumbImage.ts
+++ b/node/src/util/thumbImage.ts
@@ -91,18 +91,12 @@ export const create = async (origFilePath: string, thumbImage: Readonly<ThumbIma
 			break;
 		}
 		case 'png': {
-			const sharpOptions: Sharp.PngOptions = {
-				compressionLevel: 9,
-			};
-
 			const metadata = await sharp.metadata();
-			// @ts-expect-error: ts(2339)
-			if (metadata.format === 'png' && metadata.paletteBitDepth === 8) {
-				/* PNG8 */
-				sharpOptions.palette = true;
-			}
 
-			sharp.png(sharpOptions);
+			sharp.png({
+				compressionLevel: 9,
+				palette: metadata.isPalette /* PNG8 */,
+			});
 
 			break;
 		}


### PR DESCRIPTION
`sharp@0.34.0` にて `metadata.paletteBitDepth` が非推奨となったため、`metadata.isPalette` に変更（[Changelog](https://sharp.pixelplumbing.com/changelog/#v0340---4th-april-2025)）